### PR TITLE
Added a getCurrencySymbol method that returns only the currency's symbol

### DIFF
--- a/lib/__tests__/globalize.test.js
+++ b/lib/__tests__/globalize.test.js
@@ -153,4 +153,27 @@ describe('Globalize', () => {
       expect(numberParser('50%')).toEqual(0.5);
     });
   });
+
+  describe('getCurrencySymbol()', () => {
+    test('returns the right currency symbol for globally set locale and currency: en, USD', () => {
+      const globalize = new Globalize('en', 'USD');
+      const currencySymbol = globalize.getCurrencySymbol();
+
+      expect(currencySymbol).toEqual('$');
+    });
+
+    test('returns the right currency symbol for custom set locale and currency: nl, EUR', () => {
+      const globalize = new Globalize('en', 'USD');
+      const currencySymbol = globalize.getCurrencySymbol('nl', 'EUR');
+
+      expect(currencySymbol).toEqual('€');
+    });
+
+    test('returns the right currency symbol for global set locale and currency: de, CAD with custom alt-narrow set to true', () => {
+      const globalize = new Globalize('de', 'CAD');
+      const currencySymbol = globalize.getCurrencySymbol(null, null, true);
+
+      expect(currencySymbol).toEqual('$');
+    });
+  });
 });

--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -60,6 +60,25 @@ function localeIsLoaded(locale) {
   return !!(Cldr._raw && Cldr._raw.main && Cldr._raw.main[getLocaleKey(locale)]);
 }
 
+// Returns only the currency symbol from the CLDR file
+function getCurrencySymbol(locale, currencyCode, altNarrow) {
+
+  // Check whether the locale has been loaded
+  if (!localeIsLoaded(locale)) {
+    return null;
+  }
+
+  const currencies = Cldr._raw.main[locale].numbers.currencies;
+
+  // Check whether the given currency code exists within the CLDR file for the given locale
+  if (!Object.keys(currencies).includes(currencyCode)) {
+    return null;
+  }
+
+  // Return the right currency symbol, either the normal one or the alt-narrow one if desired
+  return altNarrow ? currencies[currencyCode]["symbol-alt-narrow"] : currencies[currencyCode].symbol;
+}
+
 // Load the Cldr data
 Globalize.load(load());
 
@@ -173,6 +192,18 @@ export default class {
     }
 
     return this._currencyFormatters[currency][key];
+  }
+
+  /**
+   * Get only the currency symbol for the given currency and locale
+   *
+   * let symbol = EN.getCurrencySymbol('en', 'USD', true);
+   */
+  getCurrencySymbol(customLocale, customCurrencyCode, altNarrow = false) {
+    const currencyCode = customCurrencyCode || this.currencyCode;
+    const locale = customLocale || this.locale;
+
+    return getCurrencySymbol(locale, currencyCode, altNarrow)
   }
 
   /**

--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -62,7 +62,6 @@ function localeIsLoaded(locale) {
 
 // Returns only the currency symbol from the CLDR file
 function getCurrencySymbol(locale, currencyCode, altNarrow) {
-
   // Check whether the locale has been loaded
   if (!localeIsLoaded(locale)) {
     return null;
@@ -76,7 +75,7 @@ function getCurrencySymbol(locale, currencyCode, altNarrow) {
   }
 
   // Return the right currency symbol, either the normal one or the alt-narrow one if desired
-  return altNarrow ? currencies[currencyCode]["symbol-alt-narrow"] : currencies[currencyCode].symbol;
+  return altNarrow ? currencies[currencyCode]['symbol-alt-narrow'] : currencies[currencyCode].symbol;
 }
 
 // Load the Cldr data
@@ -203,7 +202,7 @@ export default class {
     const currencyCode = customCurrencyCode || this.currencyCode;
     const locale = customLocale || this.locale;
 
-    return getCurrencySymbol(locale, currencyCode, altNarrow)
+    return getCurrencySymbol(locale, currencyCode, altNarrow);
   }
 
   /**


### PR DESCRIPTION
Implemented as described in https://github.com/joshswan/react-native-globalize/issues/40. This PR adds a simple method that will return just the currency's symbol for use in custom labels, settings screens or next to an input field.

This method accepts the same arguments as the `getCurrencyFormatter` method with the addition of the `altNarrow` parameter.

Usage:
```javascript
this.props.globalize.getCurrencySymbol()  // Returns the currency symbol for the globally set locale and currency code.

this.props.globalize.getCurrencySymbol('nl', 'EUR')  // Returns €

this.props.globalize.getCurrencySymbol('de', 'CAD', true)  // Returns $, since it's the alt-narrow version CAD in German.
```

I also added three tests for these scenarios.

If you have any questions let me know 👍 

