### PR TITLE
fix: export withGlobalize correctly

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -19,3 +19,4 @@ export const FormattedTime = FormattedDate;
 
 export * from './FormattedPlural';
 export { GlobalizeProvider, GlobalizeProvider as FormattedProvider };
+export { withGlobalize } from './withGlobalize';


### PR DESCRIPTION
This makes sure that withGlobalize can be imported from 'react-native-globalize'.

Currently it needs to be imported from 'react-native-globalize/dist/components/withGlobalize'