### PR TITLE
fix: export typescript types

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -19,4 +19,5 @@ export const FormattedTime = FormattedDate;
 
 export * from './FormattedPlural';
 export { GlobalizeProvider, GlobalizeProvider as FormattedProvider };
-export { withGlobalize } from './withGlobalize';
+export * from './withGlobalize';
+export { TextProps } from './utils';


### PR DESCRIPTION
This also export types so it's possible to import WithGlobalizeProps from 'react-native-globalize' instead of 'react-native-globalize/dist/...'