### PR TITLE
feat: add hoist-non-react-statics

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "cldrjs": "^0.5.0",
     "dayjs": "^1.8.20",
     "globalize": "^1.4.2",
+    "hoist-non-react-statics": "^3.3.2",
     "jsonpack": "^1.1.5"
   },
   "devDependencies": {
@@ -50,6 +51,7 @@
     "@commitlint/config-conventional": "^8.3.4",
     "@release-it/conventional-changelog": "^1.1.0",
     "@types/cldrjs": "^0.4.22",
+    "@types/hoist-non-react-statics": "^3.3.1",
     "@types/jest": "^25.1.2",
     "@types/node": "^13.7.1",
     "@typescript-eslint/eslint-plugin": "^2.19.2",

--- a/src/components/withGlobalize.tsx
+++ b/src/components/withGlobalize.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useContext } from 'react';
+import hoistStatics from 'hoist-non-react-statics';
 import { Globalize } from '../globalize';
 import { GlobalizeContext } from '../context';
 
@@ -16,8 +17,8 @@ export interface WithGlobalizeProps {
 
 export const withGlobalize = <P extends WithGlobalizeProps>(
   Component: React.ComponentType<P>,
-): React.FC<Omit<P, keyof WithGlobalizeProps>> => (props) => {
+): React.FC<Omit<P, keyof WithGlobalizeProps>> => hoistStatics((props) => {
     const globalize = useContext(GlobalizeContext);
 
     return <Component {...props as P} globalize={globalize} />;
-  };
+  }, Component);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,6 +1375,14 @@
   dependencies:
     "@types/cldrjs" "*"
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -4715,6 +4723,13 @@ hermes-engine@^0.2.1:
   resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.2.1.tgz#25c0f1ff852512a92cb5c5cc47cf967e1e722ea2"
   integrity sha512-eNHUQHuadDMJARpaqvlCZoK/Nitpj6oywq3vQ3wCwEsww5morX34mW5PmKWQTO7aU0ck0hgulxR+EVDlXygGxQ==
 
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 homedir-polyfill@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
@@ -7914,6 +7929,11 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react-is@^16.7.0:
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
+  integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
 react-native@^0.61.5:
   version "0.61.5"


### PR DESCRIPTION
This makes sure that statics fields defined on components wrapped with
withGlobalize are not lost.