### PR TITLE
Move react & react-native types to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
   },
   "dependencies": {
     "@types/globalize": "^1.5.0",
-    "@types/react": "^16.9.49",
-    "@types/react-native": "^0.63.20",
     "cldrjs": "^0.5.4",
     "dayjs": "^1.8.36",
     "globalize": "^1.6.0",
@@ -55,6 +53,8 @@
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.2",
+    "@types/react": "^16.9.49",
+    "@types/react-native": "^0.63.20",
     "@types/react-test-renderer": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",


### PR DESCRIPTION
We use this library and have different versions for react & react-native types. 
I suggest moving those deps to dev dependencies so they won't conflict with what consumers use. 