### PR TITLE
FormattedCurrency component props doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Using a `Formatted` component:
 import { FormattedCurrency } from 'react-native-globalize';
 
 export const ComponentExample = () => (
-  <FormattedCurrency currencyCode="USD" maximumFractionDigits={0} useGrouping value={1000} />
+  <FormattedCurrency currency="USD" maximumFractionDigits={0} useGrouping value={1000} />
 );
 ```
 

--- a/docs/components/FormattedCurrency.md
+++ b/docs/components/FormattedCurrency.md
@@ -20,6 +20,7 @@ const ExampleComponent = () => (
 - [`adjustsFontSizeToFit`](https://facebook.github.io/react-native/docs/text#adjustsfontsizetofit)
 - [`allowFontScaling`](https://facebook.github.io/react-native/docs/text#allowfontscaling)
 - [`compact`](#compact)
+- [`currency`](#currency)
 - [`maximumFractionDigits`](#maximumfractiondigits)
 - [`maximumSignificantDigits`](#maximumsignificantdigits)
 - [`minimumFractionDigits`](#minimumfractiondigits)
@@ -31,6 +32,27 @@ const ExampleComponent = () => (
 - [`symbolForm`](#symbolform)
 - [`useGrouping`](#usegrouping)
 - [`value`](#value)
+
+### `currency`
+
+|  Type  | Required | Default | Description |
+| :----: | :------: | :-----: | :---------: |
+| string |    No    |   GlobalizeProvider, fallback to USD  | Provides currency code for formatter. |
+
+```js
+<FormattedCurrency
+  value={1000.99}
+  currency='JPY'
+/>
+// ¥1000.99
+
+<FormattedCurrency
+  value={1000.99}
+  currency='USD'
+/>
+// $1000.99
+
+```
 
 ### `compact`
 


### PR DESCRIPTION
updates landing README prop name for FormattedCurrency component (s/currencyCode/currency/g). Adds this prop to the component document page as well

apologies if I missed something or if PRs aren't invited, this just hung me up quick on something figured I'd try and iron out any inconsistencies in the docs